### PR TITLE
feat: Add automated publish workflow for TestPyPI and PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,137 @@
+# This workflow will build and publish your Python package to TestPyPI and PyPI using trusted publishing (OIDC).
+# - Publishes to TestPyPI when a PR is opened from 'dev' to 'main' (for testing)
+# - Creates a release and publishes to PyPI when a PR from 'dev' to 'main' is merged
+# - Uses environments for deployment protection and approval gates
+
+name: Upload Python Package
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  build:
+    if: github.head_ref == 'dev' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build release distributions
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  testpypi-publish:
+    name: Publish to TestPyPI
+    if: github.head_ref == 'dev' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    permissions:
+      id-token: write
+
+    environment:
+      name: testpypi
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  create-release:
+    name: Create GitHub Release
+    if: github.head_ref == 'dev' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - testpypi-publish
+
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: get_version
+        run: |
+          if [ -f "pyproject.toml" ]; then
+            VERSION=$(grep -E '^version = ' pyproject.toml | sed 's/version = "//g' | sed 's/"//g')
+
+          elif [ -f "setup.py" ]; then
+            VERSION=$(python setup.py --version)
+
+          else
+            echo "No version file found"
+            exit 1
+
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v2
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ steps.get_version.outputs.version }} \
+            --title "v${{ steps.get_version.outputs.version }}" \
+            --notes "${{ steps.extract-release-notes.outputs.release_notes }}"
+
+  pypi-publish:
+    name: Publish to PyPI
+    if: github.head_ref == 'dev' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    needs: [build, create-release]
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fabricflow
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
## 🚀 Add Automated Package Publishing Workflow

This PR introduces a GitHub Actions workflow to automate the package publishing process.

### 📋 What's Added:
• **TestPyPI Publishing** - Automatically publishes to TestPyPI when PR is opened from `dev` to `main`
• **PyPI Publishing** - Publishes to PyPI when PR from `dev` to `main` is merged
• **GitHub Release Creation** - Automatically creates releases with version tags
• **OIDC Trusted Publishing** - Uses secure token-less publishing to PyPI
• **Release Notes Extraction** - Automatically extracts release notes from CHANGELOG.md

### 🔄 Workflow Triggers:
• PR opened/updated: `dev` → `main` (TestPyPI publish)
• PR merged: `dev` → `main` (Release creation + PyPI publish)
• Manual trigger via `workflow_dispatch`

### 🛡️ Security Features:
• Environment protection for PyPI/TestPyPI
• OIDC authentication (no stored secrets)
• Separate permissions per job