### PR TITLE
release: prepare v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-29
+
+### Added
+
+- Initial release of the `fabricflow` package.
+- Core modules for data pipeline management, including:
+  - Copy utilities (executors, job management, sinks, sources)
+  - Core utilities (capacities, connections, items, workspaces)
+  - Pipeline execution and templates
+- Templates for SQL Server to Lakehouse and Parquet file copy operations.
+- Basic logging utilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,39 @@
 [project]
 name = "fabricflow"
-description = "A code-first approach for MS Fabric data pipelines."
-version = "0.0.1"
+description = "A code-first approach for MS Fabric data pipelines and ETL."
+version = "0.1.0"
 dependencies = ["semantic-link-sempy>=0.8.0"]
 readme = "README.md"
 license = "MIT"
-authors = [{ name = "Parth Lad", email = "parthlad3915@gmail.com" }]
+license-files = ["LICENSE"]
+authors = [{ name = "Parth Lad" }]
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Database",
+]
+
+keywords = [
+    "data",
+    "pipeline",
+    "ETL",
+    "Microsoft Fabric",
+    "data engineering",
+    "dataOps",
+    "data factory pipelines",
+]
+
+[project.urls]
+Homepage = "https://github.com/ladparth/fabricflow"
+Repository = "https://github.com/ladparth/fabricflow"
+Issues = "https://github.com/ladparth/fabricflow/issues"
+Changelog = "https://github.com/ladparth/fabricflow/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = ["pytest"]


### PR DESCRIPTION
## 🏁 Release v0.1.0 - First Release

This PR triggers the official v0.1.0 release of FabricFlow.

### 🎯 Release Actions:
This PR will automatically:
• **Publish to TestPyPI** when opened (final validation)
• **Create GitHub Release v0.1.0** when merged  
• **Publish to PyPI** when merged (official release)

### 🚀 Milestone Achievement:
First release of the FabricFlow Python SDK for Microsoft Fabric data pipeline management.

---

**🎊 Ready to ship v0.1.0!**