### PR TITLE
fix: remove testpypi-publish dependency from create-release job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - testpypi-publish
 
     permissions:
       contents: write


### PR DESCRIPTION
## Fix: Remove TestPyPI dependency blocking release creation

### Problem
The `create-release` job wasn't running after PR completion because it had an unnecessary dependency on the `testpypi-publish` job, which only executes during open PRs (not when merged).

### Solution
Removed the `testpypi-publish` dependency from the `create-release` job since it only needs the build artifacts, not the TestPyPI publication.

### Changes
- Removed `testpypi-publish` from `create-release` job dependencies
- Release creation now properly runs when dev→main PRs are merged