### PR TITLE
feat: Add ServicePrincipalTokenProvider for SP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Workspace & Item Management**: CRUD operations for workspaces and core items.
 - **Connection & Capacity Utilities**: Resolve and manage connections and capacities.
 - **Logging Utilities**: Simple logging setup for consistent diagnostics.
+- **Service Principal Authentication**: Authenticate securely with Microsoft Fabric REST API using Azure Service Principal credentials.
 
 ---
 
@@ -191,6 +192,7 @@ Below are the main classes and functions available in FabricFlow:
 - `BaseSource` – Base class for sources.
 - `CopyManager` – Orchestrates and runs copy operations using predefined templates.
 - `create_workspace` – Create a new workspace and assign to a capacity.
+- `ServicePrincipalTokenProvider` – Handles Azure Service Principal authentication.
 
 ---
 

--- a/src/fabricflow/__init__.py
+++ b/src/fabricflow/__init__.py
@@ -18,6 +18,7 @@ from .copy.job.base import BaseSink, BaseSource
 from .copy.job.sources.sql_server import SQLServerSource
 from .copy.job.manager import CopyManager
 from .core.utils import create_workspace
+from .auth.provider import ServicePrincipalTokenProvider
 
 __all__: list[str] = [
     "DataPipelineExecutor",
@@ -44,6 +45,7 @@ __all__: list[str] = [
     "SQLServerSource",
     "CopyManager",
     "create_workspace",
+    "ServicePrincipalTokenProvider",
 ]
 
 logger: Logger = logging.getLogger(__name__)

--- a/src/fabricflow/auth/__init__.py
+++ b/src/fabricflow/auth/__init__.py
@@ -1,0 +1,3 @@
+from .provider import ServicePrincipalTokenProvider, TokenAcquisitionError
+
+__all__ = ["ServicePrincipalTokenProvider", "TokenAcquisitionError"]

--- a/src/fabricflow/auth/provider.py
+++ b/src/fabricflow/auth/provider.py
@@ -1,0 +1,133 @@
+from azure.identity import ClientSecretCredential
+from azure.core.credentials import AccessToken
+import logging
+from logging import Logger
+from typing import Literal
+from sempy.fabric._token_provider import TokenProvider
+
+logger: Logger = logging.getLogger(__name__)
+
+
+class TokenAcquisitionError(Exception):
+    """Custom exception for token acquisition failures."""
+
+
+PBI_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+
+
+class ServicePrincipalTokenProvider(TokenProvider):
+    """Token provider for Service Principal authentication with Microsoft Fabric REST API.
+
+    This class provides authentication tokens using Azure Service Principal credentials
+    that can be used with the FabricRestClient client from Sempy.
+    """
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ):
+        """Initialize the ServicePrincipalTokenProvider with Service Principal credentials.
+
+        Args:
+            tenant_id (str): Azure tenant ID.
+            client_id (str): Azure client ID.
+            client_secret (str): Azure client secret.
+
+        Raises:
+            ValueError: If any required credentials are missing.
+        """
+
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+        if not all([self.tenant_id, self.client_id, self.client_secret]):
+            logger.error("Missing required Service Principal credentials.")
+            raise ValueError(
+                "Missing required Service Principal credentials. "
+                "Provide tenant_id, client_id, and client_secret as parameters."
+            )
+
+        logger.debug(
+            "Initializing ClientSecretCredential for tenant_id=%s, client_id=%s",
+            self.tenant_id,
+            self.client_id,
+        )
+        self._credential = ClientSecretCredential(
+            tenant_id=self.tenant_id,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+        logger.info("ServicePrincipalTokenProvider initialized.")
+
+    # Class-level constant for audience-to-scope mapping
+    SCOPE_MAPPING = {
+        "pbi": PBI_SCOPE,
+        "storage": "https://storage.azure.com/.default",
+        "sql": "https://database.windows.net/.default",
+    }
+
+    def __call__(self, audience: Literal["pbi", "storage", "sql"] = "pbi") -> str:
+        """Get an access token for the specified audience.
+
+        This method implements the TokenProvider interface expected by Sempy.
+
+        Args:
+            audience (Literal["pbi", "storage", "sql"]): The target audience for the token.
+
+        Raises:
+            ValueError: If audience is not supported.
+            TokenAcquisitionError: If token acquisition fails.
+
+        Returns:
+            str: The access token.
+        """
+        if audience not in self.SCOPE_MAPPING:
+            logger.error("Unsupported audience: %s", audience)
+            raise ValueError(
+                f"Unsupported audience: {audience}. Must be one of: {list(self.SCOPE_MAPPING.keys())}"
+            )
+
+        scope = self.SCOPE_MAPPING[audience]
+
+        try:
+            logger.debug("Requesting token for audience: %s", audience)
+            token: AccessToken = self._credential.get_token(scope)
+            return token.token
+        except Exception as e:
+            logger.exception(
+                "Failed to acquire token for audience '%s': %s", audience, str(e)
+            )
+            raise TokenAcquisitionError(
+                f"Failed to acquire token for audience '{audience}': {str(e)}"
+            ) from e
+
+    def get_access_token(self, scope: str = PBI_SCOPE) -> AccessToken:
+        """Get the full AccessToken object for the specified scope.
+
+        Args:
+            scope (str): The target scope for the token.
+
+        Raises:
+            ValueError: If scope is not specified.
+            TokenAcquisitionError: If token acquisition fails.
+
+        Returns:
+            AccessToken: The access token object with token and expiration info.
+        """
+        if not scope:
+            logger.error("Scope must be specified to acquire token.")
+            raise ValueError("Scope must be specified to acquire token")
+
+        try:
+            logger.debug("Requesting AccessToken object for scope: %s", scope)
+            return self._credential.get_token(scope)
+        except Exception as e:
+            logger.exception(
+                "Failed to acquire access token for scope '%s': %s", scope, str(e)
+            )
+            raise TokenAcquisitionError(
+                f"Failed to acquire access token for scope '{scope}': {str(e)}"
+            ) from e


### PR DESCRIPTION

**Key Changes:**  
- Implements `ServicePrincipalTokenProvider` for Microsoft Fabric REST API authentication using Azure Service Principal credentials  
- Provides token acquisition for Power BI, Azure Storage, and Azure SQL audiences  
- Handles credential validation and error reporting  
- Leverages Azure Identity SDK for secure token management and caching  
- Adds custom exception `TokenAcquisitionError` for clear error handling  
- Exports provider and exception in `__init__.py` for package usability  

---

**Example Usage:**

```python
from fabricflow.auth.provider import ServicePrincipalTokenProvider
from sempy.fabric import FabricRestClient

token_provider = ServicePrincipalTokenProvider(
    tenant_id="your-tenant-id",
    client_id="your-client-id",
    client_secret="your-client-secret"
)

fabric_client = FabricRestClient(token_provider=token_provider)
# Now use fabric_client for authenticated operations
```

If no token provider is supplied, FabricFlow will use the notebook executor's access token (if available).