### PR TITLE
release: prepare v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2025-07-05
+
+### Added
+
+- **ServicePrincipalTokenProvider** for Microsoft Fabric REST API authentication using Azure Service Principal credentials
+
+### Changed
+
+- **CopyManager** and sink classes (`ParquetFileSink`, `LakehouseTableSink`) with improved parameter handling and error checking
+
+### Removed
+
+- `tests/copy/test_utils.py` (redundant test file)
 
 ## [0.1.0] - 2025-06-29
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # FabricFlow
 
+[![PyPI version](https://badge.fury.io/py/fabricflow.svg?icon=si%3Apython)](https://badge.fury.io/py/fabricflow)
+[![PyPI Downloads](https://static.pepy.tech/badge/fabricflow)](https://pepy.tech/projects/fabricflow)
+
+---
+
 **FabricFlow** is a code-first Python SDK for building, managing, and automating Microsoft Fabric data pipelines, workspaces, and core items. It provides a high-level, object-oriented interface for interacting with the Microsoft Fabric REST API, enabling you to create, execute, and monitor data pipelines programmatically.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fabricflow"
 description = "A code-first approach for MS Fabric data pipelines and ETL."
-version = "0.1.0"
+version = "0.1.1"
 dependencies = ["semantic-link-sempy>=0.8.0"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Key Changes**
- Bumps package version to `0.1.1` in pyproject.toml  
- Updates CHANGELOG with new features and changes  
- Adds badges to README for PyPI version and download statistics  
- Prepares the 0.1.1 release for distribution on PyPI