### PR TITLE
release: prepare v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-07-13
+
+### Added
+
+- **Google BigQuery Data Source**: New `GoogleBigQuerySource` class with connection, query execution, and batch operation support
+- **PostgreSQL Data Source**: New `PostgreSQLSource` class with connection management, query timeouts, and comprehensive parameter validation
+- **Extended Pipeline Templates**: Added BigQuery and PostgreSQL templates for copy and lookup operations
+  - `CopyGoogleBigQueryToLakehouseTable.json` - Copy data from BigQuery to Lakehouse tables
+  - `CopyGoogleBigQueryToParquetFile.json` - Copy data from BigQuery to Parquet files
+  - `CopyPostgreSQLToLakehouseTable.json` - Copy data from PostgreSQL to Lakehouse tables
+  - `CopyPostgreSQLToParquetFile.json` - Copy data from PostgreSQL to Parquet files
+  - `LookupGoogleBigQuery.json` - Lookup operations with BigQuery
+  - `LookupPostgreSQL.json` - Lookup operations with PostgreSQL
+- **Enhanced Source Types**: Added `GOOGLE_BIGQUERY` and `POSTGRESQL` to `SourceType` enum
+- **First Row Only Support**: Added `first_row_only` parameter to BigQuery and PostgreSQL sources for lookup operations
+
+### Fixed
+
+- **Template Parameter Mapping**: Fixed `sink_schema_name` and `sink_table_name` parameter assignments in pipeline templates
+- **Template Cleanup**: Removed deprecated metadata fields (`lastModifiedByObjectId`, `lastPublishTime`, `dependsOn`) from all template definitions
+
+### Changed
+
+- **Service Principal Documentation**: Added note about workspace and connection access requirements for Service Principal authentication in README
+
 ## [0.1.2] - 2025-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Below is a sample workflow that demonstrates how to use FabricFlow to automate w
 from sempy.fabric import FabricRestClient
 from fabricflow import create_workspace, create_data_pipeline
 from fabricflow.pipeline.activities import Copy, Lookup
-from fabricflow.pipeline.sources import SQLServerSource
+from fabricflow.pipeline.sources import SQLServerSource, GoogleBigQuerySource, PostgreSQLSource
 from fabricflow.pipeline.sinks import LakehouseTableSink, ParquetFileSink
 from fabricflow.pipeline.templates import (
     DataPipelineTemplates,
@@ -254,6 +254,8 @@ Below are the main classes and functions available in FabricFlow:
 ### Sources and Sinks
 
 - `SQLServerSource` – Define SQL Server as a data source.
+- `GoogleBigQuerySource` – Define Google BigQuery as a data source.
+- `PostgreSQLSource` – Define PostgreSQL as a data source.
 - `BaseSource` – Base class for all data sources.
 - `LakehouseTableSink` – Define a Lakehouse table as a data sink.
 - `ParquetFileSink` – Define a Parquet file as a data sink.
@@ -282,7 +284,7 @@ Below are the main classes and functions available in FabricFlow:
 FabricFlow provides a modular architecture with separate packages for activities, sources, sinks, and templates:
 
 - **Activities**: `Copy`, `Lookup` - Build and execute pipeline activities
-- **Sources**: `SQLServerSource`, `BaseSource`, `SourceType` - Define data sources
+- **Sources**: `SQLServerSource`, `GoogleBigQuerySource`, `PostgreSQLSource`, `BaseSource`, `SourceType` - Define data sources
 - **Sinks**: `LakehouseTableSink`, `ParquetFileSink`, `BaseSink`, `SinkType` - Define data destinations
 - **Templates**: Pre-built pipeline definitions for common patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fabricflow"
 description = "A code-first approach for MS Fabric data pipelines and ETL."
-version = "0.1.2"
+version = "0.1.3"
 dependencies = ["semantic-link-sempy>=0.8.0"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Key Changes:**

- Added support for Google BigQuery and PostgreSQL sources (Copy + Lookup)
- Introduced 6 new pipeline templates for BigQuery and PostgreSQL
- Fixed bugs in template parameter mapping and cleaned up old metadata
- Improved type system with new source enums for better consistency
- Updated docs with new examples, inline comments, and auth setup guide