### PR TITLE
release: prepare v0.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-08-30
+
+### Added
+
+- Support for custom pipeline templates via dict, enum, or file path in `create_data_pipeline` function.
+- Refactored `get_base64_str` and `get_template` functions for flexible input handling.
+- Improved display name resolution for pipelines from various template sources.
+- Enhanced type hints and documentation for better clarity.
+
 ## [0.1.4] - 2025-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ create_workspace(fabric_client, workspace_name, capacity_name)
 
 You can also create individual data pipeline templates by selecting specific templates from the list.
 
+> **New Feature**: You can now use custom pipeline templates by passing a dict (json payload), enum, or file path to `create_data_pipeline`.
+
 ```python
 for template in DataPipelineTemplates:
     create_data_pipeline(
@@ -257,7 +259,7 @@ source = FileSystemSource(
 # Define lakehouse files sink
 sink = LakehouseFilesSink(
     sink_lakehouse="data-lakehouse",
-    sink_workspace="analytics-workspace", 
+    sink_workspace="analytics-workspace",
     sink_directory="processed/files",         # Target directory in lakehouse
     copy_behavior=FileCopyBehavior.PRESERVE_HIERARCHY,  # Maintain folder structure
     enable_staging=False,                     # Direct copy without staging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fabricflow"
 description = "A code-first approach for MS Fabric data pipelines and ETL."
-version = "0.1.4"
+version = "0.1.5"
 dependencies = ["semantic-link-sempy>=0.8.0"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Key Changes:**
- Added ability to use custom pipeline templates from dict, enum, or file path.
- Refactored utility functions for flexible template input handling.
- Improved display name resolution for pipelines from various template sources.
- Enhanced type hints and documentation for better clarity.