### PR TITLE
🚀 Merge dev to main - Release FabricFlow v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-08-30
+
+### Added
+
+- Support for custom pipeline templates via dict, enum, or file path in `create_data_pipeline` function.
+- Refactored `get_base64_str` and `get_template` functions for flexible input handling.
+- Improved display name resolution for pipelines from various template sources.
+- Enhanced type hints and documentation for better clarity.
+
 ## [0.1.4] - 2025-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ create_workspace(fabric_client, workspace_name, capacity_name)
 
 You can also create individual data pipeline templates by selecting specific templates from the list.
 
+> **New Feature**: You can now use custom pipeline templates by passing a dict (json payload), enum, or file path to `create_data_pipeline`.
+
 ```python
 for template in DataPipelineTemplates:
     create_data_pipeline(
@@ -257,7 +259,7 @@ source = FileSystemSource(
 # Define lakehouse files sink
 sink = LakehouseFilesSink(
     sink_lakehouse="data-lakehouse",
-    sink_workspace="analytics-workspace", 
+    sink_workspace="analytics-workspace",
     sink_directory="processed/files",         # Target directory in lakehouse
     copy_behavior=FileCopyBehavior.PRESERVE_HIERARCHY,  # Maintain folder structure
     enable_staging=False,                     # Direct copy without staging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fabricflow"
 description = "A code-first approach for MS Fabric data pipelines and ETL."
-version = "0.1.4"
+version = "0.1.5"
 dependencies = ["semantic-link-sempy>=0.8.0"]
 readme = "README.md"
 license = "MIT"

--- a/src/fabricflow/pipeline/templates/templates.py
+++ b/src/fabricflow/pipeline/templates/templates.py
@@ -1,38 +1,14 @@
-"""
-Microsoft Fabric Data Pipeline Templates.
-
-This module provides pre-built pipeline templates for common data integration
-scenarios in Microsoft Fabric. Templates are stored as JSON files and can be
-used to quickly create data pipelines for specific source-to-sink patterns.
-
-Classes:
-    DataPipelineTemplates: Enum containing all available pipeline templates.
-
-Functions:
-    get_template: Retrieve a template definition ready for Fabric API.
-    get_base64_str: Utility function to encode template files as base64.
-
-Template Categories:
-    - Copy Activities: SQL Server to Lakehouse/Parquet with single or batch processing
-    - Copy Activities: Google BigQuery to Lakehouse/Parquet with single processing
-    - Lookup Activities: SQL Server lookup operations with optional ForEach loops
-    - Lookup Activities: Google BigQuery lookup operations with optional ForEach loops
-
-All templates support parameterization for connection details, source queries,
-and sink configurations.
-"""
+"""Microsoft Fabric Data Pipeline Templates."""
 
 from enum import Enum
 import base64
 import os
+import json
+from typing import Union, Dict, Any
 
 
 class DataPipelineTemplates(Enum):
-    """
-    Enum for Microsoft Fabric data pipeline templates.
-
-    This enum contains predefined templates for creating data pipelines.
-    """
+    """Predefined templates for Microsoft Fabric data pipelines."""
 
     COPY_SQL_SERVER_TO_LAKEHOUSE_TABLE = "CopySQLServerToLakehouseTable"
     COPY_SQL_SERVER_TO_LAKEHOUSE_TABLE_FOR_EACH = "CopySQLServerToLakehouseTableForEach"
@@ -79,42 +55,77 @@ LOOKUP_GOOGLE_BIGQUERY = DataPipelineTemplates.LOOKUP_GOOGLE_BIGQUERY
 LOOKUP_POSTGRESQL = DataPipelineTemplates.LOOKUP_POSTGRESQL
 
 
-def get_base64_str(file_path: str) -> str:
+def get_base64_str(source: Union[str, Dict[str, Any]]) -> str:
     """
-    Reads a file and returns its base64-encoded string.
+    Convert a file path (str) or pipeline definition (dict) to a base64-encoded string.
 
     Args:
-        file_path (str): Path to the file.
+        source: File path (str) or pipeline definition (dict).
 
     Returns:
-        str: Base64-encoded string of the file content.
+        Base64-encoded string of the content.
+
     Raises:
-        FileNotFoundError: If the file does not exist.
+        FileNotFoundError: If the file path does not exist.
+        TypeError: If source is neither str nor dict.
+        json.JSONEncodeError: If the dict cannot be serialized to JSON.
     """
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"File not found: {file_path}")
-    with open(file_path, "r", encoding="utf-8") as f:
-        content: str = f.read()
-    base64_bytes: bytes = base64.b64encode(content.encode("utf-8"))
+    if isinstance(source, str):
+        # Handle file path
+        if not os.path.exists(source):
+            raise FileNotFoundError(f"File not found: {source}")
+        if not source.lower().endswith(".json"):
+            raise ValueError(f"Provided file is not a JSON file: {source}")
+        with open(source, "r", encoding="utf-8") as f:
+            content = f.read()
+    elif isinstance(source, dict):
+        # Handle JSON dictionary
+        content = json.dumps(source, indent=2)
+    else:
+        raise TypeError(f"Expected str (file path) or dict (JSON), got {type(source)}")
+
+    base64_bytes = base64.b64encode(content.encode("utf-8"))
     return base64_bytes.decode("utf-8")
 
 
-def get_template(template: DataPipelineTemplates) -> dict:
+def get_template(template: Union[DataPipelineTemplates, Dict[str, Any], str]) -> dict:
     """
-    Get the base64-encoded template definition for a specific data pipeline template, formatted for Fabric REST API.
+    Get a pipeline template definition for Fabric REST API.
+
+    Supports:
+        - dict: pipeline JSON definition
+        - DataPipelineTemplates: existing template enum
+        - str: file path to template JSON
 
     Args:
-        template (DataPipelineTemplates): The data pipeline template.
+        template: dict, DataPipelineTemplates, or str (file path).
 
     Returns:
-        dict: The template definition as a dict with the correct 'definition' structure for Fabric REST API.
+        dict: Template definition for Fabric REST API.
+
     Raises:
         FileNotFoundError: If the template file does not exist.
     """
-    template_dir: str = os.path.join(os.path.dirname(__file__), "definitions")
-    template_path: str = os.path.join(template_dir, f"{template.value}.json")
+    if isinstance(template, DataPipelineTemplates):
+        template_dir: str = os.path.join(os.path.dirname(__file__), "definitions")
+        template_path: str = os.path.join(template_dir, f"{template.value}.json")
 
-    base64_str: str = get_base64_str(template_path)
+        base64_str: str = get_base64_str(template_path)
+        display_name: str = template.value
+    elif isinstance(template, (dict, str)):
+        base64_str = get_base64_str(template)
+        if isinstance(template, dict):
+            display_name = template.get("name", "Untitled Pipeline")
+        else:  # template is a file path (str)
+            display_name = os.path.splitext(os.path.basename(template))[
+                0
+            ]  # Extract file name without extension
+
+    else:
+        raise TypeError(
+            f"Expected DataPipelineTemplates, dict, or str, got {type(template)}. "
+            f"Dict can be pipeline definition and str can be template file path."
+        )
 
     return {
         "definition": {
@@ -125,5 +136,6 @@ def get_template(template: DataPipelineTemplates) -> dict:
                     "payloadType": "InlineBase64",
                 }
             ]
-        }
+        },
+        "displayName": display_name,
     }


### PR DESCRIPTION
This PR merges the latest changes from `dev` to `main` for the v0.1.5 release of FabricFlow.

🎯 **What's New in v0.1.5**

✨ **New Features**
- **Custom Pipeline Templates**: You can now use custom pipeline templates by passing a dict (JSON payload), enum, or file path to `create_data_pipeline`.
- **Flexible Template Handling**: Refactored utility functions to support multiple template input types for greater flexibility.

🔄 **Major Changes**
- **Display Name Resolution**: Improved logic for resolving display names when creating pipelines from dicts or file paths.
- **Expanded Type Hints & Docs**: Enhanced type hints and documentation for improved clarity and usability.

🛠️ **Technical Details**
- Maintains backward compatibility with existing pipeline template usage.
- Utility functions (`get_base64_str`, `get_template`) now accept dict, enum, or file path inputs.
- Streamlined comments and removed redundant module-level docstrings.

📦 **Release Artifacts**
- Version bumped to 0.1.5 in `pyproject.toml`
- `CHANGELOG.md` and `README.md` updated with new custom template support

Ready to merge and release! 🎉

Closes #32